### PR TITLE
Removed `:z` from volume map in docker-compose file and added `sudo setenforce 0` to vagrant_setup.sh

### DIFF
--- a/dev-scripts/vagrant_setup.sh
+++ b/dev-scripts/vagrant_setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 echo "running setup.sh"
+sudo setenforce 0
 sudo yum install docker -y
 sudo service docker start
 sudo yum install -y epel-release

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -5,7 +5,7 @@ services:
       - '3000:3000'
       - '8080:8080'
     volumes:
-      - .:/app:z
+      - .:/app
     build:
       dockerfile: docker/odyssey/Dockerfile.devel
       context: .


### PR DESCRIPTION
I believe this fixes the vagrant permissions issue. When I create a file in the docker container, I can now `vagrant rsync-back` on my local machine and it creates the file locally.

Let me know what your thoughts are. 